### PR TITLE
fix: rename platform default key

### DIFF
--- a/subject_platforms.yml
+++ b/subject_platforms.yml
@@ -55,7 +55,7 @@ define:
       demo: &TYPE_GAME_DEMO 4004
       table: &TYPE_GAME_TABLE 4005
 
-default:
+defaults:
   *TYPE_BOOK :
     sort_keys: ["发售日"]
     wiki_tpl: Book


### PR DESCRIPTION
跟 ts 的关键词冲突了，没法用